### PR TITLE
Added link text when reporting broken links to console

### DIFF
--- a/LinkCrawler/LinkCrawler/LinkCrawler.csproj
+++ b/LinkCrawler/LinkCrawler/LinkCrawler.csproj
@@ -77,6 +77,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Models\IResponseModel.cs" />
+    <Compile Include="Models\LinkModel.cs" />
     <Compile Include="Utils\Clients\ISlackClient.cs" />
     <Compile Include="Utils\Extensions\HttpStatusCodeExtensions.cs" />
     <Compile Include="Utils\Extensions\UriExtensions.cs" />

--- a/LinkCrawler/LinkCrawler/Models/LinkModel.cs
+++ b/LinkCrawler/LinkCrawler/Models/LinkModel.cs
@@ -1,0 +1,14 @@
+﻿namespace LinkCrawler.Models
+{
+    public class LinkModel
+    {
+        public string Url { get; set; }
+        public string InnerHtml { get; }
+
+        public LinkModel(string url, string innerHtml = "")
+        {
+            Url = url;
+            InnerHtml = innerHtml;
+        }
+    }
+}

--- a/LinkCrawler/LinkCrawler/Models/ResponseModel.cs
+++ b/LinkCrawler/LinkCrawler/Models/ResponseModel.cs
@@ -9,6 +9,7 @@ namespace LinkCrawler.Models
     public class ResponseModel : IResponseModel
     {
         public string Markup { get; }
+        public string InnerHtml { get; set; }
         public string RequestedUrl { get; }
         public string ReferrerUrl { get; }
 
@@ -32,7 +33,8 @@ namespace LinkCrawler.Models
         public override string ToString()
         {
             if (!IsSuccess)
-                return string.Format("{0}\t{1}\t{2}{3}\tReferer:\t{4}", StatusCodeNumber, StatusCode, RequestedUrl, Environment.NewLine, ReferrerUrl);
+                return string.Format("{0}\t{1}\t{2}{3}\tReferer:\t{4}{5}\tLink text:\t{6}", StatusCodeNumber, StatusCode, RequestedUrl, Environment.NewLine, ReferrerUrl,
+                                                                                            Environment.NewLine, InnerHtml);
 
             return string.Format("{0}\t{1}\t{2}", StatusCodeNumber, StatusCode, RequestedUrl);
         }


### PR DESCRIPTION
Relevant to issue #2 

![capture](https://cloud.githubusercontent.com/assets/16353894/18709016/c1918f60-7ff5-11e6-9a68-85fb073b04c9.PNG)

The approach I've taken:
1. Extend the MarkupHelper class so that it returns a list of LinkModel which contains both the Url and InnerHtml
2. Added a new property to ResponseModel to carry the InnerHtml of each Url through the program and be able to display it if necessary
3. Adjust the SendRequest method of LinkCrawler to use LinkModel instead of plain strings
4. Adjust the ToString() method of ResponseModel to include link text

Looking forward to your feedback!
