### PR TITLE
Added option to print elapsed milliseconds to console at end of process

### DIFF
--- a/LinkCrawler/LinkCrawler/App.config
+++ b/LinkCrawler/LinkCrawler/App.config
@@ -13,6 +13,7 @@
     <add key="SuccessHttpStatusCodes" value="1xx,2xx,3xx" />
     <!--explanation of regex below: http://regexr.com/3cqt9 -->
     <add key="ValidUrlRegex" value="(^http[s]?:\/{2})|(^www)|(^\/{1,2})" />
+    <add key="PrintSummary" value="false" />
     <add key="Csv.FilePath" value="C:\tmp\output.csv" />
     <add key="Csv.Overwrite" value="true" />
     <add key="Csv.Delimiter" value=";" />

--- a/LinkCrawler/LinkCrawler/Utils/Outputs/ConsoleOutput.cs
+++ b/LinkCrawler/LinkCrawler/Utils/Outputs/ConsoleOutput.cs
@@ -13,7 +13,12 @@ namespace LinkCrawler.Utils.Outputs
 
         public void WriteInfo(IResponseModel responseModel)
         {
-            Console.WriteLine(responseModel.ToString());
+            WriteInfo(responseModel.ToString());
+        }
+
+        public void WriteInfo(String Info)
+        {
+            Console.WriteLine(Info);
         }
     }
 }

--- a/LinkCrawler/LinkCrawler/Utils/Outputs/CsvOutput.cs
+++ b/LinkCrawler/LinkCrawler/Utils/Outputs/CsvOutput.cs
@@ -40,6 +40,11 @@ namespace LinkCrawler.Utils.Outputs
             Write(responseModel);
         }
 
+        public void WriteInfo(String Info)
+        {
+            // Do nothing - string info is only for console
+        }
+
         private void Write(IResponseModel responseModel)
         {
             _writer?.WriteLine("{1}{0}{2}{0}{3}{0}{4}",

--- a/LinkCrawler/LinkCrawler/Utils/Outputs/IOutput.cs
+++ b/LinkCrawler/LinkCrawler/Utils/Outputs/IOutput.cs
@@ -6,5 +6,6 @@ namespace LinkCrawler.Utils.Outputs
     {
         void WriteError(IResponseModel responseModel);
         void WriteInfo(IResponseModel responseModel);
+        void WriteInfo(string InfoString);
     }
 }

--- a/LinkCrawler/LinkCrawler/Utils/Outputs/SlackOutput.cs
+++ b/LinkCrawler/LinkCrawler/Utils/Outputs/SlackOutput.cs
@@ -21,5 +21,10 @@ namespace LinkCrawler.Utils.Outputs
         {
             // Write nothing to Slack
         }
+
+        public void WriteInfo(string Info)
+        {
+            // Write nothing to Slack
+        }
     }
 }

--- a/LinkCrawler/LinkCrawler/Utils/Settings/Constants.cs
+++ b/LinkCrawler/LinkCrawler/Utils/Settings/Constants.cs
@@ -17,6 +17,7 @@
             public const string CsvDelimiter = "Csv.Delimiter";
             public const string SuccessHttpStatusCodes = "SuccessHttpStatusCodes";
             public const string OutputProviders = "outputProviders";
+            public const string PrintSummary = "PrintSummary";
         }
 
         public static class Response

--- a/LinkCrawler/LinkCrawler/Utils/Settings/ISettings.cs
+++ b/LinkCrawler/LinkCrawler/Utils/Settings/ISettings.cs
@@ -27,5 +27,7 @@ namespace LinkCrawler.Utils.Settings
         string CsvDelimiter { get; }
 
         bool IsSuccess(HttpStatusCode statusCode);
+
+        bool PrintSummary { get; }
     }
 }

--- a/LinkCrawler/LinkCrawler/Utils/Settings/Settings.cs
+++ b/LinkCrawler/LinkCrawler/Utils/Settings/Settings.cs
@@ -39,6 +39,9 @@ namespace LinkCrawler.Utils.Settings
         public string CsvDelimiter =>
             ConfigurationManager.AppSettings[Constants.AppSettings.CsvDelimiter];
 
+        public bool PrintSummary =>
+            ConfigurationManager.AppSettings[Constants.AppSettings.PrintSummary].ToBool();
+
         public bool IsSuccess(HttpStatusCode statusCode)
         {
             var configuredCodes = ConfigurationManager.AppSettings[Constants.AppSettings.SuccessHttpStatusCodes] ?? "";


### PR DESCRIPTION
Set PrintSummary variable to true:

![printsummaryss](https://cloud.githubusercontent.com/assets/95890/18791685/a36da3d6-81ab-11e6-9384-61ca0f82914d.PNG)

And the console output will now end with:

![linkcrawlerss](https://cloud.githubusercontent.com/assets/95890/18791908/77abb656-81ac-11e6-8567-af3c056f51af.PNG)
