### PR TITLE
Refactored URL lists and added simple summary table

### DIFF
--- a/LinkCrawler/LinkCrawler.Tests/LinkCrawlerTests.cs
+++ b/LinkCrawler/LinkCrawler.Tests/LinkCrawlerTests.cs
@@ -5,6 +5,7 @@ using LinkCrawler.Utils.Parsers;
 using LinkCrawler.Utils.Settings;
 using Moq;
 using NUnit.Framework;
+using System.Linq;
 
 namespace LinkCrawler.Tests
 {
@@ -49,7 +50,7 @@ namespace LinkCrawler.Tests
             mockResponseModel.Setup(x => x.Markup).Returns(markup);
 
             LinkCrawler.CrawlForLinksInResponse(mockResponseModel.Object);
-            Assert.That(LinkCrawler.VisitedUrlList.Contains(url));
+            Assert.That(LinkCrawler.UrlList.Where(l=>l.Address == url).Count() > 0);
         }
     }
 }

--- a/LinkCrawler/LinkCrawler/LinkCrawler.cs
+++ b/LinkCrawler/LinkCrawler/LinkCrawler.cs
@@ -110,7 +110,7 @@ namespace LinkCrawler
             }
 
             // Then check to see whether there are any pending links left to check
-            if(UrlList.Where(l => l.CheckingFinished == false).Count() == 0)
+            if ((UrlList.Count > 1) && (UrlList.Where(l => l.CheckingFinished == false).Count() == 0))
             {
                 FinaliseSession();
             }
@@ -121,11 +121,24 @@ namespace LinkCrawler
             this.timer.Stop();
             if (this._settings.PrintSummary)
             {
-                string message = @"
-Processing completed in " + this.timer.ElapsedMilliseconds.ToString() + "ms";
+                List<string> messages = new List<string>();
+                messages.Add(""); // add blank line to differentiate summary from main output
+
+                messages.Add("Processing complete. Checked " + UrlList.Count() + " links in " + this.timer.ElapsedMilliseconds.ToString() + "ms");
+
+                messages.Add("");
+                messages.Add(" Status | # Links");
+                messages.Add(" -------+--------");
+
+                IEnumerable<IGrouping<int, string>> StatusSummary = UrlList.GroupBy(link => link.StatusCode, link => link.Address);
+                foreach(IGrouping<int,string> statusGroup in StatusSummary)
+                {
+                    messages.Add(String.Format("   {0}  | {1,5}", statusGroup.Key, statusGroup.Count()));
+                }
+
                 foreach (var output in Outputs)
                 {
-                    output.WriteInfo(message);
+                    output.WriteInfo(messages.ToArray());
                 }
             }
         }

--- a/LinkCrawler/LinkCrawler/LinkCrawler.csproj
+++ b/LinkCrawler/LinkCrawler/LinkCrawler.csproj
@@ -77,6 +77,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Models\IResponseModel.cs" />
+    <Compile Include="Models\LinkModel.cs" />
     <Compile Include="Utils\Clients\ISlackClient.cs" />
     <Compile Include="Utils\Extensions\HttpStatusCodeExtensions.cs" />
     <Compile Include="Utils\Extensions\UriExtensions.cs" />

--- a/LinkCrawler/LinkCrawler/Models/LinkModel.cs
+++ b/LinkCrawler/LinkCrawler/Models/LinkModel.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace LinkCrawler.Models
+{
+    public class LinkModel
+    {
+        public string Address { get; private set; }
+        public bool CheckingFinished { get; private set; }
+        private int _StatusCode;
+
+        public int StatusCode
+        {
+            get
+            {
+                return _StatusCode;
+            }
+            set
+            {
+                _StatusCode = value;
+                this.CheckingFinished = true;
+            }
+        }
+
+        public LinkModel (string Address)
+        {
+            this.Address = Address;
+            this.CheckingFinished = false;
+        }
+
+    }
+}

--- a/LinkCrawler/LinkCrawler/Utils/Outputs/ConsoleOutput.cs
+++ b/LinkCrawler/LinkCrawler/Utils/Outputs/ConsoleOutput.cs
@@ -13,12 +13,12 @@ namespace LinkCrawler.Utils.Outputs
 
         public void WriteInfo(IResponseModel responseModel)
         {
-            WriteInfo(responseModel.ToString());
+            WriteInfo(new string[] { responseModel.ToString() });
         }
 
-        public void WriteInfo(String Info)
+        public void WriteInfo(String[] Info)
         {
-            Console.WriteLine(Info);
+            foreach(string line in Info) Console.WriteLine(line);
         }
     }
 }

--- a/LinkCrawler/LinkCrawler/Utils/Outputs/CsvOutput.cs
+++ b/LinkCrawler/LinkCrawler/Utils/Outputs/CsvOutput.cs
@@ -40,7 +40,7 @@ namespace LinkCrawler.Utils.Outputs
             Write(responseModel);
         }
 
-        public void WriteInfo(String Info)
+        public void WriteInfo(String[] Info)
         {
             // Do nothing - string info is only for console
         }

--- a/LinkCrawler/LinkCrawler/Utils/Outputs/IOutput.cs
+++ b/LinkCrawler/LinkCrawler/Utils/Outputs/IOutput.cs
@@ -6,6 +6,6 @@ namespace LinkCrawler.Utils.Outputs
     {
         void WriteError(IResponseModel responseModel);
         void WriteInfo(IResponseModel responseModel);
-        void WriteInfo(string InfoString);
+        void WriteInfo(string[] InfoString);
     }
 }

--- a/LinkCrawler/LinkCrawler/Utils/Outputs/SlackOutput.cs
+++ b/LinkCrawler/LinkCrawler/Utils/Outputs/SlackOutput.cs
@@ -22,7 +22,7 @@ namespace LinkCrawler.Utils.Outputs
             // Write nothing to Slack
         }
 
-        public void WriteInfo(string Info)
+        public void WriteInfo(string[] Info)
         {
             // Write nothing to Slack
         }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ AppVeyor is used as CI, so when code is pushed to this repo the solution will ge
 | ```Slack.WebHook.Bot.MessageFormat``` | String format message that will be sent to slack  	       |
 | ```Csv.FilePath```   				  | File path for the CSV file  	   |
 | ```Csv.Overwrite```   			  | Whether to overwrite or append (if file exists)  	       |
-| ```Csv.Delimiter   ```   			  | Delimiter between columns in the CSV file (like ',' or ';')  	       |
+| ```Csv.Delimiter```   			  | Delimiter between columns in the CSV file (like ',' or ';')  	       |
+| ```PrintSummary```   			  | If true, a summary will be printed when all links have been checked.  	       |
 
 Ther also is a ```<outputProviders>``` that controls what output should be used.
 


### PR DESCRIPTION
Refactoring the two URL string lists into a list of `LinkModel` objects has made it simple to output a basic summary table to the console on completion:

![linkcrawlerss2](https://cloud.githubusercontent.com/assets/95890/19240415/41adebd8-8f02-11e6-9d1d-9aece1097b01.PNG)
