### PR TITLE
Fixed bug that causes on linux/mac for relative urls to show as absolute

### DIFF
--- a/LinkCrawler/LinkCrawler/Utils/Parsers/ValidUrlParser.cs
+++ b/LinkCrawler/LinkCrawler/Utils/Parsers/ValidUrlParser.cs
@@ -28,8 +28,8 @@ namespace LinkCrawler.Utils.Parsers
                 || !Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out parsedUri))
                 return false;
 
-            if (parsedUri.IsAbsoluteUri)
-            {
+			if (parsedUri.IsAbsoluteUri && parsedUri.IsWellFormedOriginalString()) //for Mac/mono compatibility- see https://github.com/dotnet/corefx/issues/22098
+			{
                 validUrl = url;
                 return true;
             }


### PR DESCRIPTION
Fixed bug that causes on linux mac for relative urls to be interpreted as absolute urls since they begin with /
See mono issue https://github.com/dotnet/corefx/issues/22098