### PR TITLE
Added more unit tests to ValidUrlParserTests to up coverage to 95%

### DIFF
--- a/LinkCrawler/LinkCrawler.Tests/UtilsTests/ExtensionsTests/StringExtensionsTests.cs
+++ b/LinkCrawler/LinkCrawler.Tests/UtilsTests/ExtensionsTests/StringExtensionsTests.cs
@@ -118,5 +118,14 @@ namespace LinkCrawler.Tests.UtilsTests.ExtensionsTests
             var result = word.StartsWithIgnoreCase(letter);
             Assert.AreEqual(false, result);
         }
+
+        [Test]
+        public void StartsWithIgnoreCase_NullAndNull_True()
+        {
+            string word = null;
+            string letter = null;
+            var result = StringExtensions.StartsWithIgnoreCase(null, null);
+            Assert.AreEqual(true, result);
+        }
     }
 }

--- a/LinkCrawler/LinkCrawler.Tests/UtilsTests/HelpersTests/ValidUrlParserTests.cs
+++ b/LinkCrawler/LinkCrawler.Tests/UtilsTests/HelpersTests/ValidUrlParserTests.cs
@@ -8,6 +8,7 @@ namespace LinkCrawler.Tests.UtilsTests.HelpersTests
     public class ValidUrlParserTests
     {
         public ValidUrlParser ValidUrlParser { get; set; }
+
         [SetUp]
         public void SetUp()
         {
@@ -42,9 +43,51 @@ namespace LinkCrawler.Tests.UtilsTests.HelpersTests
             string parsed;
             var result = ValidUrlParser.Parse(relativeUrl, out parsed);
             Assert.That(result, Is.True);
-            var validUrl = string.Format("{0}{1}",ValidUrlParser.BaseUrl, relativeUrl);
+            var validUrl = string.Format("{0}{1}", ValidUrlParser.BaseUrl, relativeUrl);
 
             Assert.That(parsed, Is.EqualTo(validUrl));
+        }
+
+        [Test]
+        public void When_the_url_is_empty_then_it_is_not_a_valid_url()
+        {
+            Assert.IsFalse(ValidUrlParser.Parse("", out string _));
+        }
+
+        [Test]
+        public void A_url_that_does_not_match_the_ValidUrlRegex_is_no_valid_url()
+        {
+            Assert.AreEqual(@"(^http[s]?:\/{2})|(^www)|(^\/{1,2})", new Settings().ValidUrlRegex,
+                "This test is coded against this Regex. A change in the config could make it invalid.");
+            Assert.IsFalse(ValidUrlParser.Parse("ftp://invalid.url", out string _));
+        }
+
+        [Test]
+        public void An_absolute_http_url_will_be_parsed_and_not_be_changed()
+        {
+            Assert.IsTrue(ValidUrlParser.Parse("http://www.google.de", out string url));
+            Assert.AreEqual("http://www.google.de", url);
+        }
+
+        [Test]
+        public void A_relative_url_starting_with_a_slash_will_be_expanded_to_an_absolute_url()
+        {
+            Assert.AreEqual("https://github.com", new Settings().BaseUrl, "This test is coded against a configuration using this base url and will fail if the configuration is changed.");
+            Assert.IsTrue(ValidUrlParser.Parse("/oml", out string url));
+            Assert.AreEqual("https://github.com/oml", url);
+        }
+
+        [Test]
+        public void An_url_without_a_scheme_will_get_http_prepended()
+        {
+            Assert.IsTrue(ValidUrlParser.Parse("//google.com", out string url));
+            Assert.AreEqual("http://google.com", url);
+        }
+
+        [Test]
+        public void A_relative_url_not_starting_with_a_slash_will_not_be_parsed()
+        {
+            Assert.IsFalse(ValidUrlParser.Parse("index.html", out string _));
         }
     }
 }

--- a/LinkCrawler/LinkCrawler.Tests/UtilsTests/HelpersTests/ValidUrlParserTests.cs
+++ b/LinkCrawler/LinkCrawler.Tests/UtilsTests/HelpersTests/ValidUrlParserTests.cs
@@ -51,43 +51,50 @@ namespace LinkCrawler.Tests.UtilsTests.HelpersTests
         [Test]
         public void When_the_url_is_empty_then_it_is_not_a_valid_url()
         {
-            Assert.IsFalse(ValidUrlParser.Parse("", out string _));
+            string url; 
+            Assert.IsFalse(ValidUrlParser.Parse("", out url));
         }
 
         [Test]
         public void A_url_that_does_not_match_the_ValidUrlRegex_is_no_valid_url()
         {
+            string url;
+
             Assert.AreEqual(@"(^http[s]?:\/{2})|(^www)|(^\/{1,2})", new Settings().ValidUrlRegex,
                 "This test is coded against this Regex. A change in the config could make it invalid.");
-            Assert.IsFalse(ValidUrlParser.Parse("ftp://invalid.url", out string _));
+            Assert.IsFalse(ValidUrlParser.Parse("ftp://invalid.url", out url));
         }
 
         [Test]
         public void An_absolute_http_url_will_be_parsed_and_not_be_changed()
         {
-            Assert.IsTrue(ValidUrlParser.Parse("http://www.google.de", out string url));
+            string url;
+            Assert.IsTrue(ValidUrlParser.Parse("http://www.google.de", out url));
             Assert.AreEqual("http://www.google.de", url);
         }
 
         [Test]
         public void A_relative_url_starting_with_a_slash_will_be_expanded_to_an_absolute_url()
         {
+            string url;
             Assert.AreEqual("https://github.com", new Settings().BaseUrl, "This test is coded against a configuration using this base url and will fail if the configuration is changed.");
-            Assert.IsTrue(ValidUrlParser.Parse("/oml", out string url));
+            Assert.IsTrue(ValidUrlParser.Parse("/oml", out url));
             Assert.AreEqual("https://github.com/oml", url);
         }
 
         [Test]
         public void An_url_without_a_scheme_will_get_http_prepended()
         {
-            Assert.IsTrue(ValidUrlParser.Parse("//google.com", out string url));
+            string url;
+            Assert.IsTrue(ValidUrlParser.Parse("//google.com", out url));
             Assert.AreEqual("http://google.com", url);
         }
 
         [Test]
         public void A_relative_url_not_starting_with_a_slash_will_not_be_parsed()
         {
-            Assert.IsFalse(ValidUrlParser.Parse("index.html", out string _));
+            string url;
+            Assert.IsFalse(ValidUrlParser.Parse("index.html", out url));
         }
     }
 }

--- a/LinkCrawler/LinkCrawler/Utils/Parsers/ValidUrlParser.cs
+++ b/LinkCrawler/LinkCrawler/Utils/Parsers/ValidUrlParser.cs
@@ -5,6 +5,13 @@ using System.Text.RegularExpressions;
 
 namespace LinkCrawler.Utils.Parsers
 {
+    /// <summary>
+    /// Parses a given text to validate if it is a valid url.
+    /// 
+    /// Some kinds of relative URLs are converted to absolute urls.
+    /// You can count on either getting a valid absolute url from this
+    /// class or getting a valid = false.
+    /// </summary>
     public class ValidUrlParser : IValidUrlParser
     {
         public Regex Regex { get; set; }
@@ -34,18 +41,21 @@ namespace LinkCrawler.Utils.Parsers
                 validUrl = url;
                 return true;
             }
+
             if (url.StartsWith("//"))
             {
                 var newUrl = string.Concat("http:", url);
                 validUrl = newUrl;
                 return true;
             }
+
             if (url.StartsWith("/"))
             {
                 var newUrl = string.Concat(BaseUrl, url);
                 validUrl = newUrl;
                 return true;
             }
+
             return false;
         }
     }


### PR DESCRIPTION
Hello dear HMol,

i got to your project using up-for-grabs which saw a few issues one could help with. 

I wrote a few unit tests for you to up your coverage on the ValidUrlParser from 86 to 95%. 
I can't get to 100% coverage because I could not think of an url that passes the RegEx and Uri.TryCreate test  and still fails at the other two tests for / and //. 

Please feel free to review my work and tell me everything that I may correct. 
I'd like to use that feedback then to push your coverage a little further, in a way that is benefitial to you. 
E.g. I recognized that the way I name tests is different from yours. Is that ok for you? If not, what naming convention would you like me to use?

Thank you for your work and time,
stho32